### PR TITLE
Tab completion fix for Get-File, Get-Directory and Find-ChildItem cmdlets.

### DIFF
--- a/PSDT.App.psm1
+++ b/PSDT.App.psm1
@@ -5,9 +5,11 @@ if (Test-Path Function:\TabExpansion) {
 }
 
 Function global:TabExpansion($line, $lastWord) {
-    $filter = ($line -split " " | Select-Object -Skip 1) -join ".*";
+    $cmdletStartIndex = ([string]$line).LastIndexOf('|') + 1;
+    $cmdlet = ([string]$line).Substring($cmdletStartIndex).TrimStart();
+    $filter = ($cmdlet -split " " | Select-Object -Skip 1) -join ".*";
    
-  switch -regex ($line) {
+    switch -regex ($cmdlet) {
 		"^(Get-VSSolution|gvss) .*" {
       Get-VSSolution $filter | Select-Object -ExpandProperty FullName
     }

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ PS :\> Install-Package PSDT.App
   - files,
   - any child item,
     by using multiple path segment filters.
-- Tab completion, for the above mentioned search cmdlets.
+- Tab completion for the above mentioned search cmdlets.
 
 For more information check the cmdlets provided by the module, for example:
 


### PR DESCRIPTION
The fix also solves the [Get-VSSolution cmdlet tab completion problem](https://github.com/codecraft-team/PSDT.VisualStudio/issues/10).